### PR TITLE
Docker volumes fixed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,13 @@ x-zabbix-server-db-password: &zabbix-server-db-password
 x-zabbix-server-port: &zabbix-server-port
   "10051"
 
+volumes:
+  postgres-server-data:
+  server-db-init-export:
+  server-db-init-snmptraps:
+  zabbix-server-export:
+  zabbix-server-snmptraps:
+
 services:
   server-db-init:
     image: *zabbix-server-image
@@ -37,6 +44,17 @@ services:
       POSTGRES_DB: *zabbix-server-db
       POSTGRES_USER: *zabbix-server-db-user
       POSTGRES_PASSWORD: *zabbix-server-db-password
+    volumes:
+      - type: "volume"
+        source: "server-db-init-export"
+        target: "/var/lib/zabbix/export"
+        volume:
+          nocopy: true
+      - type: "volume"
+        source: "server-db-init-snmptraps"
+        target: "/var/lib/zabbix/snmptraps"
+        volume:
+          nocopy: true
     depends_on:
       postgres-server:
         condition: "service_healthy"
@@ -52,6 +70,17 @@ services:
       POSTGRES_PASSWORD: *zabbix-server-db-password
       ZBX_LISTENPORT: *zabbix-server-port
     stop_grace_period: "1m30s"
+    volumes:
+      - type: "volume"
+        source: "zabbix-server-export"
+        target: "/var/lib/zabbix/export"
+        volume:
+          nocopy: true
+      - type: "volume"
+        source: "zabbix-server-snmptraps"
+        target: "/var/lib/zabbix/snmptraps"
+        volume:
+          nocopy: true
     depends_on:
       server-db-init:
         condition: "service_completed_successfully"
@@ -101,4 +130,10 @@ services:
       POSTGRES_USER: *zabbix-server-db-user
       POSTGRES_PASSWORD: *zabbix-server-db-password
     stop_grace_period: "2m"
+    volumes:
+      - type: "volume"
+        source: "postgres-server-data"
+        target: "/var/lib/postgresql/data"
+        volume:
+          nocopy: true
     logging: *default-logging


### PR DESCRIPTION
Notes:

1. It looks like Docker Compose cannot track Docker volumes. It simply relies on volumes declared in Compose config file and on containers (which know about volumes attached to them). It means that when removing Docker anonymous volumes (`docker compose down -v`) Compose just removes containers with all volumes attached (`docker rm -v ...`). It implies that after containers are removed (e.g. without removal of volumes - just doing `docker compose down`), Compose cannot remove anonymous volumes anymore and they are kept forever (until manual cleanup) even if `docker compose down -v` is called (i.e. `docker compose up -d`, then `docker compose down`, then `docker compose down -v` leads to dangling volumes if anonymous volumes are used).

Changes:

* Named volumes in Docker Compose project to avoid dangling volumes if Compose "down" command is used (first time) without "-v" option (if there is a need to remove volumes after containers where removed keeping existing volumes).